### PR TITLE
Fix `Net::HTTPGenericRequest::METHOD` error

### DIFF
--- a/lib/net-http-spy.rb
+++ b/lib/net-http-spy.rb
@@ -20,7 +20,7 @@ module Net
       @logger_options = defaults.merge(self.class.http_logger_options)
       @params_limit = @logger_options[:params_limit] || @logger_options[:limit]
       @body_limit   = @logger_options[:body_limit]   || @logger_options[:limit]
-      
+
       self.class.http_logger.info "CONNECT: #{args.inspect}" if !@logger_options[:verbose]
 
       old_initialize(*args, &block)
@@ -30,7 +30,7 @@ module Net
 
     def request(*args, &block)
       unless started? || @logger_options[:verbose]
-        req = args[0].class::METHOD
+        req = args[0].try(:method) || args[0].class::METHOD
         self.class.http_logger.info "#{req} #{args[0].path}"
       end
 

--- a/net-http-spy.gemspec
+++ b/net-http-spy.gemspec
@@ -5,7 +5,7 @@
 
 Gem::Specification.new do |s|
   s.name = %q{net-http-spy}
-  s.version = "0.2.1"
+  s.version = "0.2.2"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Martin Sadler"]


### PR DESCRIPTION
Got this error while running `net-http-spy` with `omniauth`.
